### PR TITLE
logging thread join failure

### DIFF
--- a/appinsights/src/channel/memory.rs
+++ b/appinsights/src/channel/memory.rs
@@ -48,7 +48,9 @@ impl InMemoryChannel {
 
         if let Some(thread) = self.thread.take() {
             debug!("Shutting down worker");
-            thread.join().unwrap();
+            if let Err(e) = thread.join() {
+                warn!("Error {:?} joining thread", e);
+            }
         }
     }
 


### PR DESCRIPTION
Log thread join error instead to prevent panic during shutdown of worker thread. 